### PR TITLE
fix(dw-dialog): initialize dialog on connectedCallback instead of firstUpdated

### DIFF
--- a/dw-dialog.js
+++ b/dw-dialog.js
@@ -284,16 +284,13 @@ export class DwDialog extends LitElement {
     }
   }
 
-  firstUpdated() {
-    this._initDialog();
-    this._listenEvents();
-    this.updateComplete.then(()=> {
-      this._checkAvailableSlot();
-    });
-  }
-
   connectedCallback() {
     super.connectedCallback && super.connectedCallback();
+    this.updateComplete.then(() => {
+      this._initDialog();
+      this._listenEvents();
+      this._checkAvailableSlot();
+    })
     if (window.visualViewport) {
       window.visualViewport.addEventListener('resize', this._visualViewPortHandler);
     }
@@ -336,11 +333,12 @@ export class DwDialog extends LitElement {
    * Opens the dialog.
    */
   open() { 
-    this._mdcDialogInstance.open();
-
-    if (this.autoFocusSelector) { 
-      this._setFocusToElement();
-    }
+    this.updateComplete.then(() => {
+      this._mdcDialogInstance.open();
+      if (this.autoFocusSelector) { 
+        this._setFocusToElement();
+      }
+    })
   }
 
   /**

--- a/dw-dialog.js
+++ b/dw-dialog.js
@@ -531,15 +531,17 @@ export class DwDialog extends LitElement {
   }
 
   _onOpenedChanged() { 
-    if (this.opened && !this._mdcDialogInstance.isOpen) { 
-      this.open();
-      return;
-    }
-
-    if (!this.opened && this._mdcDialogInstance.isOpen) { 
-      this.close();
-      return;
-    }
+    this.updateComplete.then(() => {
+      if (this.opened && !this._mdcDialogInstance.isOpen) { 
+        this.open();
+        return;
+      }
+  
+      if (!this.opened && this._mdcDialogInstance.isOpen) { 
+        this.close();
+        return;
+      }
+    })
   }
 
   _setFocusToElement() { 


### PR DESCRIPTION
Dialog initialization was being done in `firstUpdated` & it's instance properties are being set to `null` in `disconnectedCallback`.

When we use this component in `repeat` directive, on data change, `repeat` simply disconnect & connect element but don't updates it's inner DOMs. 

So on change order of item `_mdcDialogInstance` was becoming null, but `firstUpdated` was not being triggered so it was not initialized again. 

So initialization is moved to `connectedCallback` 
